### PR TITLE
feat: FW-30 Deploy image into gcp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.husky
+.github
+.next
+node_modules
+.env*
+Makefile
+README.md

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,0 +1,45 @@
+name: push docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ${{ secrets.ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev
+  IMAGE_NAME: ${{ secrets.ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev/${{ secrets.PROJECT_NAME }}/${{ secrets.REPOSITORY_NAME  }}/${{ secrets.IMAGE_NAME }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871  # v4.2.1
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70  # v2.1.6
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/${{ secrets.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ secrets.IDENTITY_POOL_ID }}/providers/${{ secrets.IDENTITY_PROVIDER_ID }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+
+      - name: Login into GCR
+        run: gcloud auth configure-docker ${{ env.REGISTRY }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75  # v6.9.0
+        id: push
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build:
+  run-checks:
     runs-on: ubuntu-latest
 
     strategy:
@@ -30,3 +30,12 @@ jobs:
 
       - name: Run linter and tests
         run: make run-checks
+
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: make build-image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Run linter and tests
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+ARG NODE_VERSION="18"
+ARG DOCKER_TAG="bookworm-slim"
+
+FROM node:${NODE_VERSION}-${DOCKER_TAG} as builder
+
+WORKDIR /app
+
+COPY . ./
+RUN npm ci && npm run build
+
+
+FROM node:${NODE_VERSION}-${DOCKER_TAG}
+
+WORKDIR /app
+
+ARG USERNAME=frontend
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+COPY --from=builder /app /app
+
+USER $USERNAME
+EXPOSE $PORT
+
+CMD ["npm", "run", "start"]

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,47 @@
-.PHONY: install-deps create-env-from-template local-setup run-app run-build run-start run-tests run-lint run-checks
-
 ENV_VARS := $(shell cat .env | xargs)
 
+IMAGE_NAME?=festwrap-ui
+IMAGE_TAG?=latest
+
+.PHONY: install-deps
 install-deps:
 	npm install
 
+.PHONY: create-env-from-template
 create-env-from-template:
 	cp .env.template .env
 
+.PHONY: local-setup
 local-setup: install-deps create-env-from-template
 
+.PHONY: run-app
 run-app:
 	@echo "Starting the frontend app..."
 	@export $(ENV_VARS) && npm run dev
 
+.PHONY: run-build
 run-build:
 	@echo "Building the frontend app..."
 	@export $(ENV_VARS) && npm run build
 
+.PHONY: run-start
 run-start:
 	@echo "Starting the production build locally..."
 	@export $(ENV_VARS) && npm run start
 
+.PHONY: run-tests
 run-tests:
 	@echo "Running tests..."
 	npm run test
 
+.PHONY: run-lint
 run-lint:
 	@echo "Running linter..."
 	npm run lint
 
+.PHONY: run-checks
 run-checks: run-lint run-tests
+
+.PHONY:
+build-image:
+	docker build -f Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .


### PR DESCRIPTION
# Description

Builds and image and publishes it into GCP on release. Sucessfully run a release on the branch (see [action](https://github.com/DanielMoraDC/festwrap-ui/actions/runs/11813154992)).

I also added a Docker image build job in the CI to test the build process on updates.