### PR TITLE
feat: FW-64 Implement artists endpoint

### DIFF
--- a/src/lib/clients/backend.ts
+++ b/src/lib/clients/backend.ts
@@ -3,7 +3,7 @@ import { AuthClient } from './auth';
 import { HttpClient, Method } from './http';
 
 export interface BackendClient {
-  searchArtists(_token: string, _name: string, _limit: number): Promise<Artist>;
+  searchArtists(_token: string, _name: string, _limit: number): Promise<Artist[]>;
 }
 
 export class HTTPBackendClient implements BackendClient {
@@ -21,7 +21,7 @@ export class HTTPBackendClient implements BackendClient {
     token: string,
     name: string,
     limit: number
-  ): Promise<Artist> {
+  ): Promise<Artist[]> {
     const authHeader = await this.buildAuthHeader();
     const backendAuthHeader = { Authorization: `Bearer ${token}` };
     return this.httpClient

--- a/src/lib/clients/backend.ts
+++ b/src/lib/clients/backend.ts
@@ -3,7 +3,11 @@ import { AuthClient } from './auth';
 import { HttpClient, Method } from './http';
 
 export interface BackendClient {
-  searchArtists(_token: string, _name: string, _limit: number): Promise<Artist[]>;
+  searchArtists(
+    _token: string,
+    _name: string,
+    _limit: number
+  ): Promise<Artist[]>;
 }
 
 export class HTTPBackendClient implements BackendClient {
@@ -47,5 +51,29 @@ export class HTTPBackendClient implements BackendClient {
     return {
       [this.authClient.getHeaderName()]: `Bearer ${authToken}`,
     };
+  }
+}
+
+export class FakeBackendClient implements BackendClient {
+  private searchArtistError: Error | undefined = undefined;
+  private searchArtistResult: Artist[];
+
+  constructor(result: Artist[] = []) {
+    this.searchArtistResult = result;
+  }
+
+  setResult(result: Artist[]) {
+    this.searchArtistResult = result;
+  }
+
+  setSearchArtistError(error: Error) {
+    this.searchArtistError = error;
+  }
+
+  async searchArtists(..._: any[]): Promise<Artist[]> {
+    if (this.searchArtistError !== undefined) {
+      throw this.searchArtistError;
+    }
+    return this.searchArtistResult;
   }
 }

--- a/src/pages/api/artists/search.test.ts
+++ b/src/pages/api/artists/search.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, vi, expect } from 'vitest';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createSearchArtistHandler, SearchArtistHandlerParams } from './search';
+import { FakeBackendClient } from '@/lib/clients/backend';
+import { Artist } from '@/lib/artists';
+
+describe('searchArtistHandler', () => {
+  function createMockRequest(
+    query: any = { name: 'Brutus', token: 'some token' }
+  ): NextApiRequest {
+    return { query } as unknown as NextApiRequest;
+  }
+
+  function createMockResponse(): NextApiResponse {
+    const response = {} as NextApiResponse;
+    response.status = vi.fn().mockReturnValue(response);
+    response.json = vi.fn().mockReturnValue(response);
+    return response;
+  }
+
+  function createHandler(
+    { client, defaultLimit, maxLimit }: SearchArtistHandlerParams = {
+      client: new FakeBackendClient(),
+      defaultLimit: 5,
+      maxLimit: 10,
+    }
+  ): (_request: NextApiRequest, _response: NextApiResponse) => Promise<void> {
+    return createSearchArtistHandler({ client, defaultLimit, maxLimit });
+  }
+
+  it.each([
+    { _title: 'not a number', limit: 'invalid' },
+    { _title: 'bigger than maximum', limit: 20 },
+  ])('should return 400 if limit is $_title', async ({ limit }) => {
+    const request = createMockRequest({ name: 'test', token: 'test', limit });
+    const response = createMockResponse();
+
+    createHandler()(request, response);
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalledWith({
+      message: `"limit" should be a number in interval [1, 10]`,
+    });
+  });
+
+  it.each([
+    {
+      _title: 'name is missing',
+      variable: 'name',
+      name: null,
+      token: 'some token',
+    },
+    {
+      _title: 'name is not a string',
+      variable: 'name',
+      name: 42,
+      token: 'some token',
+    },
+    {
+      _title: 'token is missing',
+      variable: 'token',
+      name: 'some name',
+      token: null,
+    },
+    {
+      _title: 'token is not a string',
+      variable: 'token',
+      name: 'some name',
+      token: 10,
+    },
+  ])('should return 400 if $_title', async ({ variable, name, token }) => {
+    const request = createMockRequest({ name: name, token: token });
+    const response = createMockResponse();
+
+    createHandler()(request, response);
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalledWith({
+      message: `"${variable}" should be provided as a string`,
+    });
+  });
+
+  it.each([{ limit: undefined }, { limit: 4 }])(
+    'should search with the provided arguments (limit: $limit)',
+    async ({ limit }) => {
+      const args: { name: string; token: string } = {
+        name: 'name',
+        token: 'token',
+      };
+      const request = createMockRequest({ ...args, limit: limit });
+      const client = new FakeBackendClient();
+      vi.spyOn(client, 'searchArtists');
+
+      const defaultLimit = 5;
+      createHandler({
+        client: client,
+        defaultLimit: defaultLimit,
+        maxLimit: 10,
+      })(request, createMockResponse());
+
+      expect(client.searchArtists).toBeCalledWith(
+        args.token,
+        args.name,
+        limit || defaultLimit
+      );
+    }
+  );
+
+  it('should return backend client results', async () => {
+    const retrievedArtist = [
+      new Artist('Brutus'),
+      new Artist('Brutus Daughters', 'http://some_url'),
+    ];
+    const client = new FakeBackendClient(retrievedArtist);
+    const response = createMockResponse();
+
+    const handler = createHandler({
+      client: client,
+      defaultLimit: 5,
+      maxLimit: 10,
+    });
+    await handler(createMockRequest(), response);
+
+    const expected = {
+      artists: [
+        { name: 'Brutus' },
+        { name: 'Brutus Daughters', imageUri: 'http://some_url' },
+      ],
+      message: 'Artists successfully retrieved',
+    };
+
+    expect(response.status).toBeCalledWith(200);
+    expect(response.json).toBeCalledWith(expected);
+  });
+
+  it('should return an error if search fails', async () => {
+    const client = new FakeBackendClient();
+    client.setSearchArtistError(new Error('test error'));
+    const response = createMockResponse();
+
+    const handler = createHandler({
+      client: client,
+      defaultLimit: 5,
+      maxLimit: 10,
+    });
+    await handler(createMockRequest(), response);
+
+    expect(response.status).toBeCalledWith(500);
+    expect(response.json).toBeCalledWith({
+      message: 'Unexpected error, cannot retrieve artists',
+    });
+  });
+});

--- a/src/pages/api/artists/search.ts
+++ b/src/pages/api/artists/search.ts
@@ -1,0 +1,114 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { HttpClient, HttpBaseClient } from '@/lib/clients/http';
+import { Artist } from '@/lib/artists';
+import { BackendClient, HTTPBackendClient } from '@/lib/clients/backend';
+
+export type SearchArtistHandlerParams = {
+  client: BackendClient;
+  defaultLimit: number;
+  maxLimit: number;
+};
+
+type ResponseArtist = {
+  name: string;
+  imageUri: string | undefined;
+};
+
+type ResponseData = {
+  message: string;
+  artists?: ResponseArtist[];
+};
+
+export function createSearchArtistHandler({
+  client,
+  defaultLimit,
+  maxLimit,
+}: SearchArtistHandlerParams) {
+  return async function handler(
+    request: NextApiRequest,
+    response: NextApiResponse<ResponseData>
+  ): Promise<void> {
+    const { name, token, limit } = request.query;
+
+    let parsedLimit: number;
+    try {
+      parsedLimit = parseParamNumberWithDefault(
+        limit,
+        defaultLimit,
+        maxLimit,
+        'limit'
+      );
+    } catch (e) {
+      response.status(400).json({ message: (e as Error).message });
+      return;
+    }
+
+    if (typeof name !== 'string') {
+      response
+        .status(400)
+        .json({ message: '"name" should be provided as a string' });
+      return;
+    }
+
+    if (typeof token !== 'string') {
+      response
+        .status(400)
+        .json({ message: '"token" should be provided as a string' });
+      return;
+    }
+
+    try {
+      const searchResults = await client.searchArtists(
+        token as string,
+        name as string,
+        parsedLimit
+      );
+      response.status(200).json({
+        artists: searchResults.map((artist: Artist) => ({
+          name: artist.getName(),
+          imageUri: artist.getImageUri(),
+        })),
+        message: 'Artists successfully retrieved',
+      });
+    } catch {
+      response
+        .status(500)
+        .json({ message: 'Unexpected error, cannot retrieve artists' });
+    }
+  };
+}
+
+function parseParamNumberWithDefault(
+  value: any,
+  defaultValue: number,
+  maxValue: number,
+  paramName: string
+) {
+  let parsed = defaultValue;
+  if (value !== undefined) {
+    parsed = parseInt(value as string);
+    if (isNaN(parsed) || parsed < 1 || parsed > maxValue) {
+      throw Error(
+        `"${paramName}" should be a number in interval [1, ${maxValue}]`
+      );
+    }
+  }
+  return parsed;
+}
+
+const defaultLimit: number = parseInt(
+  process.env.SEARCH_ARTISTS_DEFAULT_LIMIT || '5'
+);
+const maxLimit: number = parseInt(process.env.SEARCH_ARTISTS_MAX_LIMIT || '10');
+const serverHost: string = process.env.SERVER_HOST || 'http://localhost';
+const serverPort: number = parseInt(process.env.SERVER_PORT || '8080');
+const httpClient: HttpClient = new HttpBaseClient();
+const client: BackendClient = new HTTPBackendClient(
+  `${serverHost}:${serverPort}`,
+  httpClient
+);
+const searchArtistHandler: (
+  _request: NextApiRequest,
+  _response: NextApiResponse
+) => void = createSearchArtistHandler({ client, defaultLimit, maxLimit });
+export default searchArtistHandler;


### PR DESCRIPTION
# Description

Adds an endpoint to retrieve artists in the frontend. Implementing a wrapper on the backend endpoint so we do not have to expose the backend server.

# Test

If we start the app:

```shell
make run-app
```

Then we can open a terminal and run:

```shell
curl 'http://localhost:3000/api/artists/search?name=Iron&limit=4&token=<token>'
```

Using a proper token, this returns:

```json
{
   "artists":[
      {
         "name":"Iron & Wine",
         "imageUri":"https://i.scdn.co/image/ab6761610000f1786554f29133d7e27979e009d7"
      },
      {
         "name":"Iron Maiden",
         "imageUri":"https://i.scdn.co/image/ab6761610000f178f9978ad4808f6f2723124d19"
      },
      {
         "name":"Ironmouse",
         "imageUri":"https://i.scdn.co/image/ab6761610000f1785db1ad11adfddbcb6a57567a"
      },
      {
         "name":"The Ironix",
         "imageUri":"https://i.scdn.co/image/ab6761610000f178001e75c6cf35c402ae42a348"
      }
   ],
   "message":"Artists successfully retrieved"
}
```