### PR TITLE
chore: resolve cache image write errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
 
-COPY --from=builder /app /app
+COPY --from=builder /app .
+
+ENV CACHE_DIR=.next/cache
+RUN mkdir -p $CACHE_DIR && chown -R $USERNAME:$USER_GID $CACHE_DIR
 
 USER $USERNAME
 EXPOSE $PORT


### PR DESCRIPTION
# Context

In both prod and local, we see the following error:

```
⨯ Failed to write image to cache N7RU7KOKd-oI8BXtKNvx7eBeJ7j5QeCC26nmaxuLCSo= [Error: EACCES: permission denied, mkdir '/app/.next/cache/images'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/app/.next/cache/images'
}
 ⨯ Failed to write image to cache I0jvxvvyh45KW5ypQOtis5cqG53V1Ls3XLK1HbClov4= [Error: EACCES: permission denied, mkdir '/app/.next/cache/images'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/app/.next/cache/images'
}
 ⨯ Failed to write image to cache FGdF7UVb6DSTfOMgOyOCe11RalTaTyIXbH5xR6kiYXQ= [Error: EACCES: permission denied, mkdir '/app/.next/cache/images'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/app/.next/cache/images'
}
 ⨯ Failed to write image to cache rppwaTHKVwXCoYuVaWmeyOKQG7YiTX9bKFDL2ICCIg0= [Error: EACCES: permission denied, mkdir '/app/.next/cache/images'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/app/.next/cache/images'
}
```

This is due to the image not having enough permissions to write into the cache directory.

# Description

Allow Docker image to wrote into the cache directory, only.